### PR TITLE
Fix outfield stats not updating at full-time

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,22 @@
         };
         const initializePlayerStats = React.useCallback((gamePlayers) => { const initialStats = {}; gamePlayers.forEach(p => { initialStats[p.id] = { name: p.name, number:p.number, outfield: 0, goalie: 0 }; }); setPlayerStats(initialStats); }, []);
         const setupHalf = React.useCallback((halfNum, startingLineup = null) => { setCurrentHalf(halfNum); setTimerSeconds(0); setElapsedOnPause(0); if(halfNum === 2){ setHalf2PlayerStartTimes({}); setHalf2PlayerAccumulated({}); } let currentActualGoalie = halfNum === 1 ? goalieForHalf1 : goalieForHalf2; if (startingLineup && startingLineup.goalieId) { const selectedGoalie = players.find(p => p.id === startingLineup.goalieId); if (selectedGoalie) currentActualGoalie = selectedGoalie; } if (!currentActualGoalie) { if (halfNum === 2 && designatedGoalie1Id && !designatedGoalie2Id) { setModalMessage("CRITICAL: Select goalie for 2nd half."); setShowModal(true); setGamePhase('HalfTime'); return; } else { setModalMessage(`Goalie for Half ${halfNum} not defined.`); setShowModal(true); setGamePhase('Setup'); return; } } const halfPlan = halfNum === 1 ? substitutionPlan?.half1 : substitutionPlan?.half2; let initialFieldPlayers = []; if (startingLineup && startingLineup.outfieldIds && startingLineup.outfieldIds.length > 0) { initialFieldPlayers = players.filter(p => startingLineup.outfieldIds.includes(p.id)); } else if (halfPlan && halfPlan.length > 0 && halfPlan[0].assignments) { const firstSlotAssignments = halfPlan[0].assignments; initialFieldPlayers = players.filter(p => firstSlotAssignments[p.id] === 'ON' && p.id !== currentActualGoalie?.id); } else { const availableForOutfield = players.filter(p => p.id !== currentActualGoalie?.id); initialFieldPlayers = availableForOutfield.slice(0, OUTFIELD_PLAYERS_ON_FIELD); } setActivePlayers(players.map(p => ({ playerId: p.id, name: p.name, number: p.number, status: p.id === currentActualGoalie?.id ? 'Goalie' : initialFieldPlayers.some(fp => fp.id === p.id) ? 'Field' : 'Bench' }))); setPlanDeviated(false); setAcknowledgedPlannedSubSlotIndex(-1); setPitchPlayerPositions({});}, [players, goalieForHalf1, goalieForHalf2, designatedGoalie1Id, designatedGoalie2Id, substitutionPlan]);
-        React.useEffect(() => { let interval; if (isTimerRunning) { interval = setInterval(() => { const elapsed = Math.round((Date.now() - halfStartTime) / 1000) + elapsedOnPause; const newTimerValue = Math.min(elapsed, HALF_DURATION_SECONDS); setTimerSeconds(newTimerValue); if (newTimerValue >= HALF_DURATION_SECONDS) { setIsTimerRunning(false); if (currentHalf === 1) setGamePhase('HalfTime'); else setGamePhase('FullTime'); } }, 1000); } return () => clearInterval(interval); }, [isTimerRunning, halfStartTime, elapsedOnPause, currentHalf]);
+        React.useEffect(() => {
+          let interval;
+          if (isTimerRunning) {
+            interval = setInterval(() => {
+              const elapsed = Math.round((Date.now() - halfStartTime) / 1000) + elapsedOnPause;
+              const newTimerValue = Math.min(elapsed, HALF_DURATION_SECONDS);
+              setTimerSeconds(newTimerValue);
+              if (newTimerValue >= HALF_DURATION_SECONDS) {
+                setIsTimerRunning(false);
+                if (currentHalf === 1) setGamePhase('HalfTime');
+                else finishGame();
+              }
+            }, 1000);
+          }
+          return () => clearInterval(interval);
+        }, [isTimerRunning, halfStartTime, elapsedOnPause, currentHalf]);
         React.useEffect(() => { if (gamePhase === 'PreHalf2') setupHalf(2); }, [gamePhase, setupHalf]);
 
         // When lineup is confirmed, initialize half with selected lineup and proceed


### PR DESCRIPTION
## Summary
- ensure match timer triggers finishGame on second-half completion so outfield stats update correctly

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68921662bc10832290412981377861e2