### PR TITLE
Implement 10-minute rotation for 12-player squads

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,23 @@
             const playerSlotCountsThisHalf = {};
             playersList.forEach(p => { playerSlotCountsThisHalf[p.id] = { GK: 0, ON: 0, OFF: 0 }; });
             let currentSlotAssignments = previousSlotAssignments || {};
+            const specialOutfieldPlayers = playersList.filter(p => p.id !== goalieForThisHalfPlayer?.id);
+            if (!designatedPlayerOutfieldThisHalf && specialOutfieldPlayers.length === OUTFIELD_PLAYERS_ON_FIELD * 2) {
+                const group1 = specialOutfieldPlayers.slice(0, OUTFIELD_PLAYERS_ON_FIELD);
+                const group2 = specialOutfieldPlayers.slice(OUTFIELD_PLAYERS_ON_FIELD);
+                for (let i = 0; i < numSlotsInHalf; i++) {
+                    const newSlotAssignments = {};
+                    playersList.forEach(player => { if (cumulativePlanStats[player.id] && currentSlotAssignments[player.id] !== 'ON') { cumulativePlanStats[player.id].consecutiveON = 0; } });
+                    if (goalieForThisHalfPlayer) { newSlotAssignments[goalieForThisHalfPlayer.id] = 'GK'; cumulativePlanStats[goalieForThisHalfPlayer.id].GK++; cumulativePlanStats[goalieForThisHalfPlayer.id].consecutiveON = 0; }
+                    const activeGroup = i < numSlotsInHalf / 2 ? group1 : group2;
+                    const benchGroup = i < numSlotsInHalf / 2 ? group2 : group1;
+                    activeGroup.forEach(p => { newSlotAssignments[p.id] = 'ON'; cumulativePlanStats[p.id].ON++; cumulativePlanStats[p.id].consecutiveON = currentSlotAssignments[p.id] === 'ON' ? (cumulativePlanStats[p.id].consecutiveON || 0) + 1 : 1; if (halfNumber === 1) cumulativePlanStats[p.id].playedInH1 = true; });
+                    benchGroup.forEach(p => { newSlotAssignments[p.id] = 'OFF'; cumulativePlanStats[p.id].OFF++; cumulativePlanStats[p.id].consecutiveON = 0; });
+                    halfSlotsData.push({ assignments: newSlotAssignments });
+                    currentSlotAssignments = newSlotAssignments;
+                }
+                return halfSlotsData;
+            }
             for (let i = 0; i < numSlotsInHalf; i++) {
                 const newSlotAssignments = {};
                 playersList.forEach(player => { if (cumulativePlanStats[player.id] && currentSlotAssignments[player.id] !== 'ON') { cumulativePlanStats[player.id].consecutiveON = 0; } });


### PR DESCRIPTION
## Summary
- add special-case half planning that splits 12 outfield players into two groups of six and runs each group for 10-minute stretches

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892183b7508832290cf3618b4c89393